### PR TITLE
Spi bug fix

### DIFF
--- a/iris-fsw-softconsole/include/board_definitions.h
+++ b/iris-fsw-softconsole/include/board_definitions.h
@@ -18,18 +18,27 @@
 // DEFINITIONS AND MACROS
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------
 
+
+
 // SPI Master and Slave core definitions
 #define RTC_SPI_CORE   CORE_SPI_0
-#define RTC_SLAVE_CORE SPI_SLAVE_0  // RTC uses MSS_GPIO for SS, so this is not relevant.
+#define RTC_SLAVE_CORE SPI_SLAVE_0
 
 #define MRAM0_SPI_CORE   CORE_SPI_1
-#define MRAM0_SLAVE_CORE SPI_SLAVE_0 // MRAM0 uses MSS_GPIO for SS, so this is not relevant.
+#define MRAM0_SLAVE_CORE SPI_SLAVE_0
 
 #define FLASH_SPI_CORE   CORE_SPI_0
-#define FLASH_SLAVE_CORE SPI_SLAVE_0 // FLASH uses MSS_GPIO for SS, so this is not relevant.
+#define FLASH_SLAVE_CORE SPI_SLAVE_0
 
 #define ADCS_SPI_CORE   CORE_SPI_0
-#define ADCS_SLAVE_CORE SPI_SLAVE_0 // ADS uses MSS_GPIO for SS, so this is not relevant.
+#define ADCS_SLAVE_CORE SPI_SLAVE_0
+
+#define PROGRAM_FLASH_SPI_CORE  MSS_SPI_0
+#define PROGRAM_FLASH_WP_PIN    MSS_GPIO_8
+#define PROGRAM_FLASH_HOLD_PIN  MSS_GPIO_9
+
+//The slave core is per CoreSPI instance, so since each device is using  a
+//separate instance, they all use "slave core 0".
 
 // MSS GPIO definitions
 #define LED0          MSS_GPIO_0
@@ -41,14 +50,5 @@
 #define LED6          MSS_GPIO_6
 #define LED7          MSS_GPIO_7
 
-#define RTC_SS_PIN     MSS_GPIO_8
-#define ADC_SS_PIN     MSS_GPIO_9
-#define FLASH_SS_PIN   MSS_GPIO_10
-#define RADIO_SS_PIN   MSS_GPIO_11
-#define MRAM0_SS_PIN   MSS_GPIO_12
-#define ADCS_SS_PIN    MSS_GPIO_13
-
-#define PROGRAM_FLASH_WP_PIN	MSS_GPIO_8
-#define PROGRAM_FLASH_HOLD_PIN	MSS_GPIO_9
 
 #endif // BOARD_DEFINITIONS_H

--- a/iris-fsw-softconsole/include/drivers/protocol/spi.h
+++ b/iris-fsw-softconsole/include/drivers/protocol/spi.h
@@ -40,6 +40,7 @@ typedef enum
 {
     CORE_SPI_0,
     CORE_SPI_1,
+    MSS_SPI_0,
     NUM_SPI_INSTANCES,
 } CoreSPIInstance_t;
 
@@ -133,7 +134,6 @@ void spi_transaction_block_read_with_toggle(
 void spi_transaction_block_write_without_toggle(
     CoreSPIInstance_t core,  // The SPI core used.
     spi_slave_t slave,       // The SPI slave configuration to use.
-	mss_gpio_id_t pin,       // The GPIO pin to use for the slave select.
     uint8_t * cmd_buffer,    // The buffer containing the command.
     uint16_t cmd_size,         // The size of the command buffer.
     uint8_t * wr_buffer,     // The buffer containing the data to write.
@@ -148,7 +148,6 @@ void spi_transaction_block_write_without_toggle(
 void spi_transaction_block_read_without_toggle(
     CoreSPIInstance_t core,  // The SPI core used.
     spi_slave_t slave,       // The SPI slave configuration to use.
-	mss_gpio_id_t pin,       // The GPIO pin to use for the slave select.
     uint8_t * cmd_buffer,    // The buffer containing the command.
     uint16_t cmd_size,         // The size of the command buffer.
     uint8_t * rd_buffer,     // The buffer containing the data to write.

--- a/iris-fsw-softconsole/include/drivers/protocol/spi.h
+++ b/iris-fsw-softconsole/include/drivers/protocol/spi.h
@@ -32,6 +32,7 @@
 #define WAIT_FOR_CORE_MAX_DELAY(core) 	WAIT_FOR_CORE(core, portMAX_DELAY)                       // Macro for acquiring a FreeRTOS mutex for an SPI core, with a timeout of portMAX_DELAY.
 #define RELEASE_CORE(core) 				xSemaphoreGive(core_lock[(core)])                        // Macro for releasing a FreeRTOS mutex for an SPI core.
 
+#define SPI_BUFF_SIZE                   512
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------
 // ENUMS AND ENUM TYPEDEFS
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/iris-fsw-softconsole/src/drivers/device/adcs_driver.c
+++ b/iris-fsw-softconsole/src/drivers/device/adcs_driver.c
@@ -39,9 +39,6 @@ AdcsDriverError_t adcs_init_driver(){
 
 	AdcsDriverError_t status = ADCS_DRIVER_NO_ERROR;
 
-	//spi_configure_slave(ADCS_SPI_CORE, ADCS_SLAVE_CORE, SPI_MODE_MASTER, SPI_MODE3, PCLK_DIV_32);
-	spi_configure_gpio_ss(ADCS_SS_PIN);
-
 }
 
 AdcsDriverError_t adcs_power_on(){
@@ -51,7 +48,7 @@ AdcsDriverError_t adcs_power_on(){
     uint8_t cmd[2] = {(ADCS_POWER_ON>>8)&0xFF,ADCS_POWER_ON&0xFF};
     uint8_t ack [1+sizeof(cmd)] = {0}; // The acknowledge consists of 0x01 followed by the command echoed back.
 
-    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,cmd,sizeof(cmd),ack,sizeof(ack));
+    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,cmd,sizeof(cmd),ack,sizeof(ack));
 
     if(ack[0] != ADCS_ACK_PREFIX || (ack[1]<<8+ack[2]) != ADCS_POWER_ON){
 
@@ -69,7 +66,7 @@ AdcsDriverError_t adcs_power_off(){
     uint8_t cmd[2] = {(ADCS_POWER_OFF>>8)&0xFF,ADCS_POWER_OFF&0xFF};
     uint8_t ack [1+sizeof(cmd)] = {0}; // The acknowledge consists of 0x01 followed by the command echoed back.
 
-    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,cmd,sizeof(cmd),ack,sizeof(ack));
+    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,cmd,sizeof(cmd),ack,sizeof(ack));
 
     if(ack[0] != ADCS_ACK_PREFIX || (ack[1]<<8+ack[2]) != ADCS_POWER_OFF){
 
@@ -88,7 +85,7 @@ AdcsDriverError_t adcs_initiate_telemetry(){
     uint8_t cmd[2] = {(ADSC_INITIATE_TELEMETRY>>8)&0xFF,ADSC_INITIATE_TELEMETRY&0xFF};
     uint8_t ack [1+sizeof(cmd)] = {0}; // The acknowledge consists of 0x01 followed by the command echoed back.
 
-    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,cmd,sizeof(cmd),ack,sizeof(ack));
+    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,cmd,sizeof(cmd),ack,sizeof(ack));
 
     if(ack[0] != ADCS_ACK_PREFIX || (ack[1]<<8+ack[2]) != ADSC_INITIATE_TELEMETRY){
 
@@ -107,7 +104,7 @@ AdcsDriverError_t adcs_read_telemetry(uint8_t * databuffer){
     uint8_t cmd[2] = {(ADCS_READ_TELEMETRY>>8)&0xFF,ADCS_READ_TELEMETRY&0xFF};
     uint8_t ack [1+sizeof(cmd)] = {0}; // The acknowledge consists of 0x01 followed by the command echoed back.
 
-    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,cmd,sizeof(cmd),ack,sizeof(ack));
+    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,cmd,sizeof(cmd),ack,sizeof(ack));
 
     if(ack[0] != ADCS_ACK_PREFIX || (ack[1]<<8+ack[2]) != ADCS_READ_TELEMETRY){
 
@@ -115,7 +112,7 @@ AdcsDriverError_t adcs_read_telemetry(uint8_t * databuffer){
     }
     else{
 
-        spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,NULL,0,databuffer,ADCS_TELEMETRY_TOTAL_SIZE);
+        spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,NULL,0,databuffer,ADCS_TELEMETRY_TOTAL_SIZE);
     }
 
     return status;
@@ -157,7 +154,7 @@ AdcsDriverError_t adcs_turn_on_magnetorquer(MagnetorquerID_t id, uint8_t pwm_dut
     
     uint8_t ack [1+sizeof(cmd)] = {0}; // The acknowledge consists of 0x01 followed by the command echoed back.
 
-    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,cmd,sizeof(cmd),ack,sizeof(ack));
+    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,cmd,sizeof(cmd),ack,sizeof(ack));
 
     if( (ack[0] != ADCS_ACK_PREFIX) || (ack[1] != cmd[1]) || (ack[2] != ack[2]) ){
 
@@ -202,7 +199,7 @@ AdcsDriverError_t status = ADCS_DRIVER_NO_ERROR;
     
     uint8_t ack [1+sizeof(cmd)] = {0}; // The acknowledge consists of 0x01 followed by the command echoed back.
 
-    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,cmd,sizeof(cmd),ack,sizeof(ack));
+    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,cmd,sizeof(cmd),ack,sizeof(ack));
 
     if( (ack[0] != ADCS_ACK_PREFIX) || (ack[1] != cmd[1]) || (ack[2] != ack[2]) ){
 
@@ -221,7 +218,7 @@ AdcsDriverError_t adcs_reset(){
     uint8_t cmd[2] = {(ADCS_RESET>>8)&0xFF,ADCS_RESET&0xFF};
     uint8_t ack [1+sizeof(cmd)] = {0}; // The acknowledge consists of 0x01 followed by the command echoed back.
 
-    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,cmd,sizeof(cmd),ack,sizeof(ack));
+    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,cmd,sizeof(cmd),ack,sizeof(ack));
 
     if(ack[0] != ADCS_ACK_PREFIX || (ack[1]<<8+ack[2]) != ADCS_RESET){
 
@@ -240,7 +237,7 @@ AdcsDriverError_t adcs_read_magnetorquer_data(uint8_t * databuffer){
     uint8_t cmd= ADCS_READ_MAGNETORQUERS;
     uint8_t ack [1+sizeof(cmd)] = {0}; // The acknowledge consists of 0x01 followed by the command echoed back.
 
-    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,&cmd,sizeof(cmd),ack,sizeof(ack));
+    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,&cmd,sizeof(cmd),ack,sizeof(ack));
 
     if(ack[0] != ADCS_ACK_PREFIX ||(ack[1] != ADCS_READ_MAGNETORQUERS)){
 
@@ -248,7 +245,7 @@ AdcsDriverError_t adcs_read_magnetorquer_data(uint8_t * databuffer){
     }
     else{
 
-        spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,NULL,0,databuffer,ADCS_MAGNETORQUER_DATA_SIZE);
+        spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,NULL,0,databuffer,ADCS_MAGNETORQUER_DATA_SIZE);
     }
 
     return status;
@@ -262,7 +259,7 @@ AdcsDriverError_t adcs_read_gyro_data(uint8_t * databuffer){
     uint8_t cmd= ADCS_READ_GYRO;
     uint8_t ack [1+sizeof(cmd)] = {0}; // The acknowledge consists of 0x01 followed by the command echoed back.
 
-    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,&cmd,sizeof(cmd),ack,sizeof(ack));
+    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,&cmd,sizeof(cmd),ack,sizeof(ack));
 
     if(ack[0] != ADCS_ACK_PREFIX ||(ack[1] != ADCS_READ_GYRO)){
 
@@ -270,7 +267,7 @@ AdcsDriverError_t adcs_read_gyro_data(uint8_t * databuffer){
     }
     else{
 
-        spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,NULL,0,databuffer,ADCS_GYRO_DATA_SIZE);
+        spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,NULL,0,databuffer,ADCS_GYRO_DATA_SIZE);
     }
 
     return status;
@@ -284,7 +281,7 @@ AdcsDriverError_t adcs_read_sunsensor_data(uint8_t* databuffer){
     uint8_t cmd= ADCS_READ_SUN_SENSOR;
     uint8_t ack [1+sizeof(cmd)] = {0}; // The acknowledge consists of 0x01 followed by the command echoed back.
 
-    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,&cmd,sizeof(cmd),ack,sizeof(ack));
+    spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,&cmd,sizeof(cmd),ack,sizeof(ack));
 
     if(ack[0] != ADCS_ACK_PREFIX ||(ack[1] != ADCS_READ_SUN_SENSOR)){
 
@@ -292,7 +289,7 @@ AdcsDriverError_t adcs_read_sunsensor_data(uint8_t* databuffer){
     }
     else{
 
-        spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,ADCS_SS_PIN,NULL,0,databuffer,ADCS_SUN_SENSOR_DATA_SIZE);
+        spi_transaction_block_read_without_toggle(ADCS_SPI_CORE,ADCS_SLAVE_CORE,NULL,0,databuffer,ADCS_SUN_SENSOR_DATA_SIZE);
     }
 
     return status;

--- a/iris-fsw-softconsole/src/drivers/device/memory/flash_common.c
+++ b/iris-fsw-softconsole/src/drivers/device/memory/flash_common.c
@@ -148,6 +148,10 @@ FlashStatus_t flash_erase_device(FlashDev_t *device){
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------
 // DEVICE SPECIFIC FUNCTIONS
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------
+//These are used so that we can easily modify the basic spi functions used for each driver.
+//Each Flash driver ultimately just does spi read and spi write, so we write the drivers to use these functions.
+//This makes it so we only have to change these in one place instead of all across the flash drivers.
+
 
 void data_flash_spi_read(uint8_t *cmd_buffer,uint16_t cmd_size,uint8_t *rd_buffer,uint16_t rd_size){
 	spi_transaction_block_read_without_toggle(FLASH_SPI_CORE, FLASH_SLAVE_CORE, FLASH_SS_PIN, cmd_buffer, cmd_size, rd_buffer, rd_size);
@@ -165,19 +169,20 @@ void program_flash_spi_read(uint8_t *cmd_buffer, uint16_t cmd_size, uint8_t *rd_
 }
 void program_flash_spi_write(uint8_t *cmd_buffer,uint16_t cmd_size,uint8_t *wr_buffer,uint16_t wr_size){
 
-	//TODO: Should we use a static buffer instead of malloc? If not we need to handle if malloc fails.
-	//Our (core) spi driver does the same thing.
-
 	//Put the command and data into one buffer.
 	uint32_t total_count = cmd_size + wr_size;
-	uint8_t * buffer = pvPortMalloc(total_count);
 
-	memcpy(buffer,cmd_buffer,cmd_size);
-	memcpy(&buffer[cmd_size],wr_buffer,wr_size);
+    if(total_count < SPI_BUFF_SIZE){
 
+        memcpy(spi_temp_buff,cmd_buffer,cmd_size);
+        memcpy(&spi_temp_buff[cmd_size],wr_buffer,wr_size);
 
-    MSS_SPI_set_slave_select(&g_mss_spi0,MSS_SPI_SLAVE_0);
-    MSS_SPI_transfer_block(&g_mss_spi0,buffer, total_count, 0, 0);
-	MSS_SPI_clear_slave_select(&g_mss_spi0,MSS_SPI_SLAVE_0);
-	vPortFree(buffer);
+        MSS_SPI_set_slave_select(&g_mss_spi0,MSS_SPI_SLAVE_0);
+        MSS_SPI_transfer_block(&g_mss_spi0,spi_temp_buff, total_count, 0, 0);
+        MSS_SPI_clear_slave_select(&g_mss_spi0,MSS_SPI_SLAVE_0);
+
+    }
+    else{
+        while(1){}
+    }
 }

--- a/iris-fsw-softconsole/src/drivers/device/memory/flash_common.c
+++ b/iris-fsw-softconsole/src/drivers/device/memory/flash_common.c
@@ -15,7 +15,6 @@
 #include "drivers/device/memory/MT25Q_flash.h"
 #include "drivers/device/memory/AT25SF_flash.h"
 #include "drivers/protocol/spi.h"
-#include <firmware/drivers/mss_spi/mss_spi.h>
 #include "board_definitions.h"
 
 //Device specific spi functions
@@ -154,35 +153,18 @@ FlashStatus_t flash_erase_device(FlashDev_t *device){
 
 
 void data_flash_spi_read(uint8_t *cmd_buffer,uint16_t cmd_size,uint8_t *rd_buffer,uint16_t rd_size){
-	spi_transaction_block_read_without_toggle(FLASH_SPI_CORE, FLASH_SLAVE_CORE, FLASH_SS_PIN, cmd_buffer, cmd_size, rd_buffer, rd_size);
+	spi_transaction_block_read_without_toggle(FLASH_SPI_CORE, FLASH_SLAVE_CORE,  cmd_buffer, cmd_size, rd_buffer, rd_size);
 }
 void data_flash_spi_write(uint8_t *cmd_buffer,uint16_t cmd_size,uint8_t *wr_buffer,uint16_t wr_size){
-	spi_transaction_block_write_without_toggle(FLASH_SPI_CORE, FLASH_SLAVE_CORE, FLASH_SS_PIN, cmd_buffer, cmd_size, wr_buffer, wr_size);
+	spi_transaction_block_write_without_toggle(FLASH_SPI_CORE, FLASH_SLAVE_CORE,  cmd_buffer, cmd_size, wr_buffer, wr_size);
 }
 
 void program_flash_spi_read(uint8_t *cmd_buffer, uint16_t cmd_size, uint8_t *rd_buffer, uint16_t rd_size){
 
-    MSS_SPI_set_slave_select(&g_mss_spi0,MSS_SPI_SLAVE_0);
-    MSS_SPI_transfer_block(&g_mss_spi0,cmd_buffer, cmd_size, rd_buffer, rd_size);
-	MSS_SPI_clear_slave_select(&g_mss_spi0,MSS_SPI_SLAVE_0);
+    spi_transaction_block_read_without_toggle(FLASH_SPI_CORE, FLASH_SLAVE_CORE, cmd_buffer, cmd_size, rd_buffer, rd_size);
 
 }
 void program_flash_spi_write(uint8_t *cmd_buffer,uint16_t cmd_size,uint8_t *wr_buffer,uint16_t wr_size){
 
-	//Put the command and data into one buffer.
-	uint32_t total_count = cmd_size + wr_size;
-
-    if(total_count < SPI_BUFF_SIZE){
-
-        memcpy(spi_temp_buff,cmd_buffer,cmd_size);
-        memcpy(&spi_temp_buff[cmd_size],wr_buffer,wr_size);
-
-        MSS_SPI_set_slave_select(&g_mss_spi0,MSS_SPI_SLAVE_0);
-        MSS_SPI_transfer_block(&g_mss_spi0,spi_temp_buff, total_count, 0, 0);
-        MSS_SPI_clear_slave_select(&g_mss_spi0,MSS_SPI_SLAVE_0);
-
-    }
-    else{
-        while(1){}
-    }
+    spi_transaction_block_write_without_toggle(PROGRAM_FLASH_SPI_CORE, FLASH_SLAVE_CORE, cmd_buffer, cmd_size, wr_buffer, wr_size);
 }

--- a/iris-fsw-softconsole/src/drivers/device/memory/mr2xh40_mram.c
+++ b/iris-fsw-softconsole/src/drivers/device/memory/mr2xh40_mram.c
@@ -60,7 +60,6 @@ void mr2xh40_read_status_register(MRAMInstance_t * mram, uint8_t * buffer)
 	spi_transaction_block_read_without_toggle(
 				mram->core,
 				mram->slave,
-				mram->cs_pin,
 				&cmd,
 				1,
 				buffer,
@@ -78,7 +77,7 @@ void mr2xh40_read(MRAMInstance_t * mram, uint32_t address, uint8_t * rd_buffer, 
 	spi_transaction_block_read_without_toggle(
 					mram->core,
 					mram->slave,
-					mram->cs_pin,
+
 					cmd,
 					sizeof(cmd),
 					rd_buffer,
@@ -98,7 +97,6 @@ void mr2xh40_write(MRAMInstance_t * mram, uint32_t address, uint8_t * wr_buffer,
 	spi_transaction_block_write_without_toggle(
 					mram->core,
 					mram->slave,
-					mram->cs_pin,
 					cmd,
 					sizeof(cmd),
 					wr_buffer,
@@ -113,7 +111,6 @@ static void mr2xh40_single_cmd(MRAMInstance_t * mram, uint8_t cmd)
     spi_transaction_block_read_without_toggle(
        mram->core,
        mram->slave,
-       mram->cs_pin,
        &cmd,
        1,
        NULL,

--- a/iris-fsw-softconsole/src/drivers/device/memory/mram.c
+++ b/iris-fsw-softconsole/src/drivers/device/memory/mram.c
@@ -22,10 +22,10 @@
 // VARIABLES
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-// Use this list to maintain the list of MRAMs and the core/slave/ss pins used.
+// Use this list to maintain the list of MRAMs and the core/slave pins used.
 MRAMInstance_t mram_instances[NUM_MRAM_INSTANCES] = {
-    //                    core instance,   slave instance,       ss pin
-    [MRAM_INSTANCE_0] = { MRAM0_SPI_CORE,  MRAM0_SLAVE_CORE,     MRAM0_SS_PIN }
+    //                    core instance,   slave instance
+    [MRAM_INSTANCE_0] = { MRAM0_SPI_CORE,  MRAM0_SLAVE_CORE}
 };
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/iris-fsw-softconsole/src/drivers/device/rtc/rtc_ds1393.c
+++ b/iris-fsw-softconsole/src/drivers/device/rtc/rtc_ds1393.c
@@ -30,8 +30,7 @@
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------
 void ds1393_init()
 {
-	//spi_configure_slave(RTC_SPI_CORE, RTC_SLAVE_CORE, SPI_MODE_MASTER, SPI_MODE3, PCLK_DIV_256);
-	spi_configure_gpio_ss(RTC_SS_PIN);
+
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -47,7 +46,6 @@ void ds1393_read_time(Calendar_t * read_buffer)
 	spi_transaction_block_read_without_toggle(
 			RTC_SPI_CORE,
 			RTC_SLAVE_CORE,
-			RTC_SS_PIN,
 			&address,
 			1,
 			buffer,
@@ -78,7 +76,6 @@ void ds1393_write_time(Calendar_t * write_buffer)
 	spi_transaction_block_write_without_toggle(
 			RTC_SPI_CORE,
 			RTC_SLAVE_CORE,
-			RTC_SS_PIN,
 			&address,
 			1,
 			buffer,
@@ -91,7 +88,6 @@ void ds1393_read_reg(DS1393RegAddresses_t address, uint8_t * buffer)
 	spi_transaction_block_read_without_toggle(
 			RTC_SPI_CORE,
 			RTC_SLAVE_CORE,
-			RTC_SS_PIN,
 			&address,
 			1,
 			buffer,
@@ -105,7 +101,6 @@ void ds1393_write_reg(DS1393RegAddresses_t address, uint8_t value)
 	spi_transaction_block_write_without_toggle(
 			RTC_SPI_CORE,
 			RTC_SLAVE_CORE,
-			RTC_SS_PIN,
 			&address,
 			1,
 			&value,

--- a/iris-fsw-softconsole/src/drivers/protocol/spi.c
+++ b/iris-fsw-softconsole/src/drivers/protocol/spi.c
@@ -46,7 +46,10 @@ addr_t core_base_addr[NUM_SPI_INSTANCES] = {	CORESPI_C0_0,
 uint16_t core_fifo_len[NUM_SPI_INSTANCES] = {	8,
 												8};
 
-//SPI
+//SPI tempoary buffer
+uint8_t spi_temp_buff[SPI_BUFF_SIZE];
+
+
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------
 // FUNCTIONS
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -123,20 +126,20 @@ void spi_transaction_block_write_without_toggle(CoreSPIInstance_t core, spi_slav
 
 	//Put the command and data into one buffer.
 	uint32_t total_count = cmd_size + wr_size;
-	uint8_t * buffer = pvPortMalloc(total_count);
 
+	if(total_count < SPI_BUFF_SIZE){
 
-	if(buffer != NULL){
-
-        memcpy(buffer,cmd_buffer,cmd_size);
-        memcpy(&buffer[cmd_size],wr_buffer,wr_size);
+        memcpy(spi_temp_buff,cmd_buffer,cmd_size);
+        memcpy(&spi_temp_buff[cmd_size],wr_buffer,wr_size);
 
         //Select the slave and then perform SPI transfer.
         SPI_set_slave_select(&core_spi[core], slave);
-        SPI_transfer_block(&core_spi[core],buffer, total_count, 0, 0);
+        SPI_transfer_block(&core_spi[core],spi_temp_buff, total_count, 0, 0);
         SPI_clear_slave_select(&core_spi[core],slave);
 
-        vPortFree(buffer);
+	}
+	else{
+	    while(1){}// Just loop here for now, until we add error code.
 	}
 }
 

--- a/iris-fsw-softconsole/src/drivers/protocol/spi.c
+++ b/iris-fsw-softconsole/src/drivers/protocol/spi.c
@@ -122,13 +122,14 @@ void spi_transaction_block_read_with_toggle(CoreSPIInstance_t core, spi_slave_t 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------
 void spi_transaction_block_write_without_toggle(CoreSPIInstance_t core, spi_slave_t slave, mss_gpio_id_t pin, uint8_t * cmd_buffer, uint16_t cmd_size, uint8_t * wr_buffer, uint16_t wr_size)
 {
-	//TODO: Should we use a static buffer instead of malloc? If not we need to handle if malloc fails.
 
 	//Put the command and data into one buffer.
 	uint32_t total_count = cmd_size + wr_size;
 
 	if(total_count < SPI_BUFF_SIZE){
 
+		//Copy the data into the static buffer.
+		//We should not need to clear the buffer since we overwrite previous data and know the length.
         memcpy(spi_temp_buff,cmd_buffer,cmd_size);
         memcpy(&spi_temp_buff[cmd_size],wr_buffer,wr_size);
 
@@ -139,6 +140,9 @@ void spi_transaction_block_write_without_toggle(CoreSPIInstance_t core, spi_slav
 
 	}
 	else{
+		//Handle when the data exceeds the size of the static buffer.
+		//Shouldn't really happen since we can increase size of the buffer
+		//during development or modify the calling code..
 	    while(1){}// Just loop here for now, until we add error code.
 	}
 }

--- a/iris-fsw-softconsole/src/drivers/protocol/spi.c
+++ b/iris-fsw-softconsole/src/drivers/protocol/spi.c
@@ -131,6 +131,7 @@ void spi_transaction_block_write_without_toggle(CoreSPIInstance_t core, spi_slav
     SPI_transfer_block(&core_spi[core],buffer, total_count, 0, 0);
     SPI_clear_slave_select(&core_spi[core],slave);
 
+    vPortFree(buffer);
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/iris-fsw-softconsole/src/drivers/protocol/spi.c
+++ b/iris-fsw-softconsole/src/drivers/protocol/spi.c
@@ -45,6 +45,8 @@ addr_t core_base_addr[NUM_SPI_INSTANCES] = {	CORESPI_C0_0,
 //The length of each CoreSPI fifo.
 uint16_t core_fifo_len[NUM_SPI_INSTANCES] = {	8,
 												8};
+
+//SPI
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------
 // FUNCTIONS
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -123,15 +125,19 @@ void spi_transaction_block_write_without_toggle(CoreSPIInstance_t core, spi_slav
 	uint32_t total_count = cmd_size + wr_size;
 	uint8_t * buffer = pvPortMalloc(total_count);
 
-	memcpy(buffer,cmd_buffer,cmd_size);
-	memcpy(&buffer[cmd_size],wr_buffer,wr_size);
 
-	//Select the slave and then perform SPI transfer.
-    SPI_set_slave_select(&core_spi[core], slave);
-    SPI_transfer_block(&core_spi[core],buffer, total_count, 0, 0);
-    SPI_clear_slave_select(&core_spi[core],slave);
+	if(buffer != NULL){
 
-    vPortFree(buffer);
+        memcpy(buffer,cmd_buffer,cmd_size);
+        memcpy(&buffer[cmd_size],wr_buffer,wr_size);
+
+        //Select the slave and then perform SPI transfer.
+        SPI_set_slave_select(&core_spi[core], slave);
+        SPI_transfer_block(&core_spi[core],buffer, total_count, 0, 0);
+        SPI_clear_slave_select(&core_spi[core],slave);
+
+        vPortFree(buffer);
+	}
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/iris-fsw-softconsole/tests/spi_tests.c
+++ b/iris-fsw-softconsole/tests/spi_tests.c
@@ -28,7 +28,6 @@ void vTestSPI(void *pvParameters)
         spi_transaction_block_write_without_toggle(
                     CORE_SPI_0,
                     SPI_SLAVE_0,
-					MSS_GPIO_0,
                     test_cmd,
                     sizeof(test_cmd) / sizeof(test_cmd[0]),
                     test_wr,
@@ -41,7 +40,6 @@ void vTestSPI(void *pvParameters)
         spi_transaction_block_read_without_toggle(
                     CORE_SPI_0,
                     SPI_SLAVE_0,
-					MSS_GPIO_0,
                     test_cmd,
                     sizeof(test_cmd) / sizeof(test_cmd[0]),
                     test_rd,


### PR DESCRIPTION
This fixes the memory leak described in #9.

The SPI code now uses a statically allocated buffer for combining commands and write data.
I chose the buffer size based on nothing really, so we can easily increase/decrease it if we run into a situation where we need to transfer more than 512 bytes. The buffer size is defined in spi.h.

To test this I just ran the MRAM test, which uses SPI, so it shows that the spi driver still works.
And since we no longer call malloc, the memory leak is gone.